### PR TITLE
Phase 1 cleanup: security fixes, dedup, and FormRequests

### DIFF
--- a/src/Chuck/Accessors/Chuck.php
+++ b/src/Chuck/Accessors/Chuck.php
@@ -192,15 +192,6 @@ class Chuck
                     Route::get('/dashboard/forms/{slug}/entries', '\Chuckbe\Chuckcms\Controllers\FormController@entries')->name('dashboard.forms.entries');
                 });
 
-                Route::group(['middleware' => ['permission:create formentries']], function () {
-                });
-
-                Route::group(['middleware' => ['permission:edit formentries']], function () {
-                });
-
-                Route::group(['middleware' => ['permission:delete formentries']], function () {
-                });
-
                 // Dashboard Content Resource Routes...
                 Route::group(['middleware' => ['permission:show resource']], function () {
                     Route::get('/dashboard/content/resources', '\Chuckbe\Chuckcms\Controllers\ContentController@resourceIndex')->name('dashboard.content.resources');

--- a/src/Chuck/PageBlockRepository.php
+++ b/src/Chuck/PageBlockRepository.php
@@ -23,47 +23,12 @@ class PageBlockRepository
     {
         $pageblocks = [];
         foreach ($ogpageblocks as $pageblock) {
-            $body = $pageblock->body;
-            $findUrlTags = TagParser::between($body, '[%', '%]');
-            $url = env('APP_URL', ChuckSite::getSetting('domain'));
-            if (count($findUrlTags) > 0) {
-                foreach ($findUrlTags as $foundUrlTag) {
-                    if (strpos($foundUrlTag, 'URL') !== false) {
-                        $body = str_replace('[%URL%]', $url, $body);
-                    }
-                }
-            }
-
-            $findThis = TagParser::between($body, '[', ']');
-
-            // THERE ARE DYNAMICS IN THIS PAGEBLOCK, LET'S RETRIEVE IT
-            if (count($findThis) > 0) {
-                //@todo LOOP OVER findThis variable and resolve order for rendering
-
-                // PAGEBLOCK CONTAINS A LOOP, LET'S RETRIEVE IT
-                if (strpos($findThis[0], 'LOOP') !== false) {
-                    $repeater_slug = implode(' ', TagParser::between($body, '[LOOP=', ']'));
-                    $repeater_body = implode(' ', TagParser::between($body, '[LOOP='.$repeater_slug.']', '[/LOOP]'));
-
-                    $newbody = str_replace('[LOOP='.$repeater_slug.']'.$repeater_body.'[/LOOP]', $this->getRepeaterContents($repeater_slug, $repeater_body), $body);
-
-                // THERE IS NO LOOP, CONTINUE
-                } elseif (strpos($findThis[0], 'FORM') !== false) {// PAGEBLOCK CONTAINS A FORM, LET'S RETRIEVE IT
-                    $form_slug = implode(' ', TagParser::between($body, '[FORM=', ']'));
-
-                    $newbody = $this->getFormHtml($form_slug, $body);
-                } else {// THERE IS NO FORM, SO JUST RETRIEVE THE DYNAMIC CONTENT
-                    $newbody = $this->getResourceContent($findThis, $pageblock->id, $body); //Maybe write a function in the model?
-                }
-            } else {
-                $newbody = $body;
-            }
             $pageblocks[] = [
                 'id'      => $pageblock->id,
                 'page_id' => $pageblock->page_id,
                 'name'    => $pageblock->name,
                 'slug'    => $pageblock->slug,
-                'body'    => $newbody,
+                'body'    => $this->renderBody($pageblock),
                 'raw'     => $pageblock->body,
                 'order'   => $pageblock->order,
             ];
@@ -74,7 +39,26 @@ class PageBlockRepository
 
     public function getRenderedByPageBlock($pageblock)
     {
+        return [
+            'id'      => $pageblock->id,
+            'page_id' => $pageblock->page_id,
+            'name'    => $pageblock->name,
+            'slug'    => $pageblock->slug,
+            'body'    => $this->renderBody($pageblock),
+            'raw'     => $pageblock->body,
+            'lang'    => $pageblock->lang,
+        ];
+    }
+
+    /**
+     * Resolve every dynamic tag inside a single page-block body and
+     * return the rendered HTML. Handles [%URL%], [LOOP=...], [FORM=...]
+     * and plain [resource+key] interpolation.
+     */
+    private function renderBody($pageblock)
+    {
         $body = $pageblock->body;
+
         $findUrlTags = TagParser::between($body, '[%', '%]');
         $url = env('APP_URL', ChuckSite::getSetting('domain'));
         if (count($findUrlTags) > 0) {
@@ -86,39 +70,31 @@ class PageBlockRepository
         }
 
         $findThis = TagParser::between($body, '[', ']');
-        // THERE ARE DYNAMICS IN THIS PAGEBLOCK, LET'S RETRIEVE IT
-        if (count($findThis) > 0) {
-            //@todo LOOP OVER findThis variable and resolve order for rendering
 
-            // PAGEBLOCK CONTAINS A LOOP, LET'S RETRIEVE IT
-            if (strpos($findThis[0], 'LOOP') !== false) {
-                $repeater_slug = implode(' ', TagParser::between($body, '[LOOP=', ']'));
-                $repeater_body = implode(' ', TagParser::between($body, '[LOOP='.$repeater_slug.']', '[/LOOP]'));
-
-                $newbody = str_replace('[LOOP='.$repeater_slug.']'.$repeater_body.'[/LOOP]', $this->getRepeaterContents($repeater_slug, $repeater_body), $body);
-
-            // THERE IS NO LOOP, CONTINUE
-            } elseif (strpos($findThis[0], 'FORM') !== false) {// PAGEBLOCK CONTAINS A FORM, LET'S RETRIEVE IT
-                $form_slug = implode(' ', TagParser::between($body, '[FORM=', ']'));
-
-                $newbody = $this->getFormHtml($form_slug, $body);
-            } else {// THERE IS NO FORM, SO JUST RETRIEVE THE DYNAMIC CONTENT
-                $newbody = $this->getResourceContent($findThis, $pageblock->id, $body); //Maybe write a function in the model?
-            }
-        } else {
-            $newbody = $body;
+        // No dynamics inside this pageblock, return body as-is.
+        if (count($findThis) === 0) {
+            return $body;
         }
-        $new_pageblock = [
-            'id'      => $pageblock->id,
-            'page_id' => $pageblock->page_id,
-            'name'    => $pageblock->name,
-            'slug'    => $pageblock->slug,
-            'body'    => $newbody,
-            'raw'     => $pageblock->body,
-            'lang'    => $pageblock->lang,
-        ];
 
-        return $new_pageblock;
+        //@todo LOOP OVER findThis variable and resolve order for rendering
+
+        // PAGEBLOCK CONTAINS A LOOP, LET'S RETRIEVE IT
+        if (strpos($findThis[0], 'LOOP') !== false) {
+            $repeater_slug = implode(' ', TagParser::between($body, '[LOOP=', ']'));
+            $repeater_body = implode(' ', TagParser::between($body, '[LOOP='.$repeater_slug.']', '[/LOOP]'));
+
+            return str_replace('[LOOP='.$repeater_slug.']'.$repeater_body.'[/LOOP]', $this->getRepeaterContents($repeater_slug, $repeater_body), $body);
+        }
+
+        // PAGEBLOCK CONTAINS A FORM, LET'S RETRIEVE IT
+        if (strpos($findThis[0], 'FORM') !== false) {
+            $form_slug = implode(' ', TagParser::between($body, '[FORM=', ']'));
+
+            return $this->getFormHtml($form_slug, $body);
+        }
+
+        // Plain dynamic resource interpolation.
+        return $this->getResourceContent($findThis, $pageblock->id, $body);
     }
 
     public function updateBody($pageblock, $html)

--- a/src/Chuck/PageBlockRepository.php
+++ b/src/Chuck/PageBlockRepository.php
@@ -2,6 +2,7 @@
 
 namespace Chuckbe\Chuckcms\Chuck;
 
+use Chuckbe\Chuckcms\Chuck\Support\TagParser;
 use Chuckbe\Chuckcms\Models\Form;
 use Chuckbe\Chuckcms\Models\PageBlock;
 use Chuckbe\Chuckcms\Models\Repeater;
@@ -23,7 +24,7 @@ class PageBlockRepository
         $pageblocks = [];
         foreach ($ogpageblocks as $pageblock) {
             $body = $pageblock->body;
-            $findUrlTags = $this->getResources($body, '[%', '%]');
+            $findUrlTags = TagParser::between($body, '[%', '%]');
             $url = env('APP_URL', ChuckSite::getSetting('domain'));
             if (count($findUrlTags) > 0) {
                 foreach ($findUrlTags as $foundUrlTag) {
@@ -33,7 +34,7 @@ class PageBlockRepository
                 }
             }
 
-            $findThis = $this->getResources($body, '[', ']');
+            $findThis = TagParser::between($body, '[', ']');
 
             // THERE ARE DYNAMICS IN THIS PAGEBLOCK, LET'S RETRIEVE IT
             if (count($findThis) > 0) {
@@ -41,14 +42,14 @@ class PageBlockRepository
 
                 // PAGEBLOCK CONTAINS A LOOP, LET'S RETRIEVE IT
                 if (strpos($findThis[0], 'LOOP') !== false) {
-                    $repeater_slug = implode(' ', $this->getResources($body, '[LOOP=', ']'));
-                    $repeater_body = implode(' ', $this->getResources($body, '[LOOP='.$repeater_slug.']', '[/LOOP]'));
+                    $repeater_slug = implode(' ', TagParser::between($body, '[LOOP=', ']'));
+                    $repeater_body = implode(' ', TagParser::between($body, '[LOOP='.$repeater_slug.']', '[/LOOP]'));
 
                     $newbody = str_replace('[LOOP='.$repeater_slug.']'.$repeater_body.'[/LOOP]', $this->getRepeaterContents($repeater_slug, $repeater_body), $body);
 
                 // THERE IS NO LOOP, CONTINUE
                 } elseif (strpos($findThis[0], 'FORM') !== false) {// PAGEBLOCK CONTAINS A FORM, LET'S RETRIEVE IT
-                    $form_slug = implode(' ', $this->getResources($body, '[FORM=', ']'));
+                    $form_slug = implode(' ', TagParser::between($body, '[FORM=', ']'));
 
                     $newbody = $this->getFormHtml($form_slug, $body);
                 } else {// THERE IS NO FORM, SO JUST RETRIEVE THE DYNAMIC CONTENT
@@ -74,7 +75,7 @@ class PageBlockRepository
     public function getRenderedByPageBlock($pageblock)
     {
         $body = $pageblock->body;
-        $findUrlTags = $this->getResources($body, '[%', '%]');
+        $findUrlTags = TagParser::between($body, '[%', '%]');
         $url = env('APP_URL', ChuckSite::getSetting('domain'));
         if (count($findUrlTags) > 0) {
             foreach ($findUrlTags as $foundUrlTag) {
@@ -84,21 +85,21 @@ class PageBlockRepository
             }
         }
 
-        $findThis = $this->getResources($body, '[', ']');
+        $findThis = TagParser::between($body, '[', ']');
         // THERE ARE DYNAMICS IN THIS PAGEBLOCK, LET'S RETRIEVE IT
         if (count($findThis) > 0) {
             //@todo LOOP OVER findThis variable and resolve order for rendering
 
             // PAGEBLOCK CONTAINS A LOOP, LET'S RETRIEVE IT
             if (strpos($findThis[0], 'LOOP') !== false) {
-                $repeater_slug = implode(' ', $this->getResources($body, '[LOOP=', ']'));
-                $repeater_body = implode(' ', $this->getResources($body, '[LOOP='.$repeater_slug.']', '[/LOOP]'));
+                $repeater_slug = implode(' ', TagParser::between($body, '[LOOP=', ']'));
+                $repeater_body = implode(' ', TagParser::between($body, '[LOOP='.$repeater_slug.']', '[/LOOP]'));
 
                 $newbody = str_replace('[LOOP='.$repeater_slug.']'.$repeater_body.'[/LOOP]', $this->getRepeaterContents($repeater_slug, $repeater_body), $body);
 
             // THERE IS NO LOOP, CONTINUE
             } elseif (strpos($findThis[0], 'FORM') !== false) {// PAGEBLOCK CONTAINS A FORM, LET'S RETRIEVE IT
-                $form_slug = implode(' ', $this->getResources($body, '[FORM=', ']'));
+                $form_slug = implode(' ', TagParser::between($body, '[FORM=', ']'));
 
                 $newbody = $this->getFormHtml($form_slug, $body);
             } else {// THERE IS NO FORM, SO JUST RETRIEVE THE DYNAMIC CONTENT
@@ -126,25 +127,6 @@ class PageBlockRepository
         $pageblock->update();
 
         return $this->getRenderedByPageBlock($pageblock);
-    }
-
-    public function getResources($str, $startDelimiter, $endDelimiter)
-    {
-        $contents = [];
-        $startDelimiterLength = strlen($startDelimiter);
-        $endDelimiterLength = strlen($endDelimiter);
-        $startFrom = 0;
-        while (false !== ($contentStart = strpos($str, $startDelimiter, $startFrom))) {
-            $contentStart += $startDelimiterLength;
-            $contentEnd = strpos($str, $endDelimiter, $contentStart);
-            if (false === $contentEnd) {
-                break;
-            }
-            $contents[] = substr($str, $contentStart, $contentEnd - $contentStart);
-            $startFrom = $contentEnd + $endDelimiterLength;
-        }
-
-        return $contents;
     }
 
     public function getResourceContent($resources, $page_block_id, $page_block_body)
@@ -184,7 +166,7 @@ class PageBlockRepository
         } else {
             $contents = Repeater::where('slug', $slug)->get();
         }
-        $resources = $this->getResources($page_block_body, '['.$slug.'+', ']');
+        $resources = TagParser::between($page_block_body, '['.$slug.'+', ']');
         $new_body = [];
         $i = 0;
         foreach ($contents as $content) {

--- a/src/Chuck/Support/TagParser.php
+++ b/src/Chuck/Support/TagParser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Chuck\Support;
+
+class TagParser
+{
+    /**
+     * Return every substring sandwiched between matching $startDelimiter
+     * and $endDelimiter occurrences in $str. Identical semantics to the
+     * three copies that previously lived in Models\\Form, Models\\Content
+     * and Chuck\\PageBlockRepository.
+     *
+     * @return string[]
+     */
+    public static function between(string $str, string $startDelimiter, string $endDelimiter): array
+    {
+        $contents = [];
+        $startDelimiterLength = strlen($startDelimiter);
+        $endDelimiterLength = strlen($endDelimiter);
+        $startFrom = 0;
+
+        while (false !== ($contentStart = strpos($str, $startDelimiter, $startFrom))) {
+            $contentStart += $startDelimiterLength;
+            $contentEnd = strpos($str, $endDelimiter, $contentStart);
+            if (false === $contentEnd) {
+                break;
+            }
+            $contents[] = substr($str, $contentStart, $contentEnd - $contentStart);
+            $startFrom = $contentEnd + $endDelimiterLength;
+        }
+
+        return $contents;
+    }
+}

--- a/src/Chuck/Support/TemplateBlocks.php
+++ b/src/Chuck/Support/TemplateBlocks.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Chuck\Support;
+
+class TemplateBlocks
+{
+    /**
+     * Recursively scan a template's blocks directory and return a nested
+     * array describing every .html block file, the path to its preview
+     * image (if any), and a human-readable name.
+     *
+     * Output shape (per leaf):
+     *   [
+     *     'name'     => 'header logo',
+     *     'location' => '/path/to/template/blocks/header-logo.html',
+     *     'img'      => '/path/to/preview.jpg' | fallback URL,
+     *   ]
+     */
+    public static function scan(string $dir): array
+    {
+        if (!is_dir($dir)) {
+            return [];
+        }
+
+        $result = [];
+        foreach (scandir($dir) as $value) {
+            if ($value === '.' || $value === '..' || $value === '.DS_Store') {
+                continue;
+            }
+
+            $fullPath = $dir.DIRECTORY_SEPARATOR.$value;
+
+            if (is_dir($fullPath)) {
+                $result[$value] = self::scan($fullPath);
+                continue;
+            }
+
+            if (strpos($value, '.html') === false) {
+                continue;
+            }
+
+            $blockKey = str_replace('.html', '', $value);
+            $blockName = str_replace('-', ' ', $blockKey);
+            $result[$blockKey] = [
+                'name'     => $blockName,
+                'location' => $fullPath,
+                'img'      => self::resolvePreviewImage($dir, $blockKey),
+            ];
+        }
+
+        return $result;
+    }
+
+    private static function resolvePreviewImage(string $dir, string $blockKey): string
+    {
+        foreach (['jpg', 'jpeg', 'png'] as $ext) {
+            $candidate = $dir.DIRECTORY_SEPARATOR.$blockKey.'.'.$ext;
+            if (file_exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return 'https://ui-avatars.com/api/?length=5&size=150&name=BLOCK&background=0D8ABC&color=fff&font-size=0.2';
+    }
+}

--- a/src/Chuck/Support/TemplateBlocks.php
+++ b/src/Chuck/Support/TemplateBlocks.php
@@ -32,6 +32,7 @@ class TemplateBlocks
 
             if (is_dir($fullPath)) {
                 $result[$value] = self::scan($fullPath);
+
                 continue;
             }
 

--- a/src/ChuckcmsServiceProvider.php
+++ b/src/ChuckcmsServiceProvider.php
@@ -6,9 +6,7 @@ use Chuckbe\Chuckcms\Commands\GenerateRolesPermissions;
 use Chuckbe\Chuckcms\Commands\GenerateSite;
 use Chuckbe\Chuckcms\Commands\GenerateSitemap;
 use Chuckbe\Chuckcms\Commands\GenerateSuperAdmin;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Permission\Middlewares\PermissionMiddleware;
 use Spatie\Permission\Middlewares\RoleMiddleware;
@@ -49,8 +47,6 @@ class ChuckcmsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['App\User'] = $this->app['Chuckbe\Chuckcms\Models\User'];
-
         $this->loadViewsFrom(__DIR__.'/views', 'chuckcms');
         // publish error views + publish updated lfm views
 
@@ -95,24 +91,5 @@ class ChuckcmsServiceProvider extends ServiceProvider
             __DIR__.'/../config/lfm.php'      => config_path('lfm.php'),
             __DIR__.'/../config/lang.php'     => config_path('lang.php'),
         ], 'chuckcms-config');
-    }
-
-    /**
-     * Returns existing migration file if found, else uses the current timestamp.
-     *
-     * @return string
-     */
-    public function getMigrationFileName($migrationFileName): string
-    {
-        $timestamp = date('Y_m_d_His');
-
-        $filesystem = $this->app->make(Filesystem::class);
-
-        return Collection::make($this->app->databasePath().DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR)
-            ->flatMap(function ($path) use ($filesystem, $migrationFileName) {
-                return $filesystem->glob($path.'*_'.$migrationFileName);
-            })
-            ->push($this->app->databasePath()."/migrations/{$timestamp}_{$migrationFileName}")
-            ->first();
     }
 }

--- a/src/Controllers/ContentController.php
+++ b/src/Controllers/ContentController.php
@@ -7,6 +7,10 @@ use Chuckbe\Chuckcms\Models\Repeater;
 use Chuckbe\Chuckcms\Models\Resource;
 use Chuckbe\Chuckcms\Models\Template;
 use Chuckbe\Chuckcms\Models\User;
+use Chuckbe\Chuckcms\Requests\Content\DeleteRepeaterRequest;
+use Chuckbe\Chuckcms\Requests\Content\DeleteResourceRequest;
+use Chuckbe\Chuckcms\Requests\Content\ImportRepeaterRequest;
+use Chuckbe\Chuckcms\Requests\Content\SaveResourceRequest;
 use ChuckSite;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
@@ -52,15 +56,8 @@ class ContentController extends BaseController
         return view('chuckcms::backend.content.resource.edit', compact('resource'));
     }
 
-    public function resourceSave(Request $request)
+    public function resourceSave(SaveResourceRequest $request)
     {
-        //validate the request
-        $this->validate(request(), [//@todo create custom Request class for site validation
-            'slug'             => 'required',
-            'resource_key.*'   => 'required',
-            'resource_value.*' => 'required',
-        ]);
-
         $resource = Resource::firstOrNew(['slug' => $request->get('slug')[0]]);
         $resource->slug = $request->get('slug')[0];
         $json = [];
@@ -76,12 +73,8 @@ class ContentController extends BaseController
         return redirect()->route('dashboard.content.resources');
     }
 
-    public function resourceDelete(Request $request)
+    public function resourceDelete(DeleteResourceRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for site validation
-            'resource_id' => 'required',
-        ]);
-
         $resource = Resource::where('id', $request->get('resource_id'))->first();
 
         if ($resource->delete()) {
@@ -170,13 +163,8 @@ class ContentController extends BaseController
         return redirect()->route('dashboard.content.repeaters');
     }
 
-    public function repeaterImport(Request $request)
+    public function repeaterImport(ImportRepeaterRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'slug' => 'required',
-            'file' => 'required|file|mimetypes:application/json,application/octet-stream,text/plain',
-        ]);
-
         $file_contents = file_get_contents($request->file('file'));
 
         $new_slug = $request->get('slug');
@@ -227,12 +215,8 @@ class ContentController extends BaseController
         return redirect()->route('dashboard.content.repeaters')->with('notification', $notification);
     }
 
-    public function repeaterDelete(Request $request)
+    public function repeaterDelete(DeleteRepeaterRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for site validation
-            'content_id' => 'required',
-        ]);
-
         $content = Content::where('id', $request->get('content_id'))->first();
         $repeaters = Repeater::where('slug', $content->slug)->delete();
 

--- a/src/Controllers/ContentController.php
+++ b/src/Controllers/ContentController.php
@@ -21,24 +21,16 @@ class ContentController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $content;
-    private $resource;
-    private $repeater;
-    private $template;
-    private $user;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Content $content, Resource $resource, Repeater $repeater, Template $template, User $user)
-    {
-        $this->content = $content;
-        $this->resource = $resource;
-        $this->repeater = $repeater;
-        $this->template = $template;
-        $this->user = $user;
+    public function __construct(
+        private Content $content,
+        private Resource $resource,
+        private Repeater $repeater,
+        private Template $template,
+        private User $user,
+    ) {
     }
 
     public function resourceIndex()

--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -21,30 +21,19 @@ class DashboardController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    protected $template;
-    protected $site;
-    protected $page;
-    protected $pageblock;
-    protected $pageBlockRepository;
-    protected $resource;
-    protected $repeater;
-    protected $user;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Template $template, Site $site, Page $page, PageBlock $pageblock, PageBlockRepository $pageBlockRepository, Resource $resource, Repeater $repeater, User $user)
-    {
-        $this->template = $template;
-        $this->site = $site;
-        $this->page = $page;
-        $this->pageblock = $pageblock;
-        $this->pageBlockRepository = $pageBlockRepository;
-        $this->resource = $resource;
-        $this->repeater = $repeater;
-        $this->user = $user;
+    public function __construct(
+        protected Template $template,
+        protected Site $site,
+        protected Page $page,
+        protected PageBlock $pageblock,
+        protected PageBlockRepository $pageBlockRepository,
+        protected Resource $resource,
+        protected Repeater $repeater,
+        protected User $user,
+    ) {
         $this->middleware('auth');
     }
 

--- a/src/Controllers/FormController.php
+++ b/src/Controllers/FormController.php
@@ -20,20 +20,14 @@ class FormController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $form;
-    private $formEntry;
-    private $template;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Form $form, FormEntry $formEntry, Template $template)
-    {
-        $this->form = $form;
-        $this->formEntry = $formEntry;
-        $this->template = $template;
+    public function __construct(
+        private Form $form,
+        private FormEntry $formEntry,
+        private Template $template,
+    ) {
     }
 
     public function index()

--- a/src/Controllers/FrontEndController.php
+++ b/src/Controllers/FrontEndController.php
@@ -22,34 +22,17 @@ class FrontEndController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $page;
-    private $pageblock;
-    private $pageBlockRepository;
-    private $redirect;
-    private $repeater;
-    private $role;
-    private $template;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
     public function __construct(
-        Page $page,
-        PageBlock $pageblock,
-        PageBlockRepository $pageBlockRepository,
-        Redirect $redirect,
-        Repeater $repeater,
-        Role $role,
-        Template $template
+        private Page $page,
+        private PageBlock $pageblock,
+        private PageBlockRepository $pageBlockRepository,
+        private Redirect $redirect,
+        private Repeater $repeater,
+        private Template $template,
     ) {
-        $this->page = $page;
-        $this->pageblock = $pageblock;
-        $this->pageBlockRepository = $pageBlockRepository;
-        $this->redirect = $redirect;
-        $this->repeater = $repeater;
-        $this->template = $template;
     }
 
     public function index($slug = null)

--- a/src/Controllers/MatomoController.php
+++ b/src/Controllers/MatomoController.php
@@ -20,25 +20,20 @@ class MatomoController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $site;
-    private $siteRepository;
-    private $user;
     private $siteId;
     private $authToken;
     private $matomoUrl;
 
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Site $site, SiteRepository $siteRepository, User $user)
-    {
-        $this->site = $site;
+    public function __construct(
+        private Site $site,
+        private SiteRepository $siteRepository,
+        private User $user,
+    ) {
         $this->siteId = ChuckSite::getSetting('integrations.matomo-site-id');
         $this->authToken = ChuckSite::getSetting('integrations.matomo-auth-key');
-        $this->siteRepository = $siteRepository;
-        $this->user = $user;
         $this->matomoUrl = ChuckSite::getSetting('integrations.matomo-site-url');
     }
 

--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -16,16 +16,11 @@ class MenuController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    protected $page;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Page $page)
+    public function __construct(protected Page $page)
     {
-        $this->page = $page;
     }
 
     /**

--- a/src/Controllers/PageBlockController.php
+++ b/src/Controllers/PageBlockController.php
@@ -129,7 +129,7 @@ class PageBlockController extends BaseController
         $contents = File::get($this->resolveBlockLocation($request['location']));
         $page = $this->page->getById($request['page_id']);
         $this->pageblock->addBlockTop($contents, $page, $request['name']);
-        //return $pageblock;
+
         return 'success';
     }
 
@@ -150,7 +150,7 @@ class PageBlockController extends BaseController
         $contents = File::get($this->resolveBlockLocation($request['location']));
         $page = $this->page->getById($request['page_id']);
         $this->pageblock->addBlockBottom($contents, $page, $request['name']);
-        //return $pageblock;
+
         return 'success';
     }
 

--- a/src/Controllers/PageBlockController.php
+++ b/src/Controllers/PageBlockController.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class PageBlockController extends BaseController
 {
@@ -134,7 +135,7 @@ class PageBlockController extends BaseController
         }
 
         // AUTHORIZE ... COMES HERE
-        $contents = File::get($request['location']);
+        $contents = File::get($this->resolveBlockLocation($request['location']));
         $page = $this->page->getById($request['page_id']);
         $this->pageblock->addBlockTop($contents, $page, $request['name']);
         //return $pageblock;
@@ -155,10 +156,40 @@ class PageBlockController extends BaseController
         }
 
         // AUTHORIZE ... COMES HERE
-        $contents = File::get($request['location']);
+        $contents = File::get($this->resolveBlockLocation($request['location']));
         $page = $this->page->getById($request['page_id']);
         $this->pageblock->addBlockBottom($contents, $page, $request['name']);
         //return $pageblock;
         return 'success';
+    }
+
+    /**
+     * Resolve a user-supplied block location to an absolute path inside one of
+     * the active templates' /blocks directories. This guards against path
+     * traversal: only .html files that physically live under an active
+     * template's blocks/ directory are accepted.
+     */
+    private function resolveBlockLocation(?string $location): string
+    {
+        if ($location === null || $location === '') {
+            throw new NotFoundHttpException('Invalid block location.');
+        }
+
+        $real = realpath($location);
+        if ($real === false || !is_file($real) || !str_ends_with($real, '.html')) {
+            throw new NotFoundHttpException('Invalid block location.');
+        }
+
+        foreach ($this->template->where('active', 1)->get() as $template) {
+            $allowed = realpath($template->path.DIRECTORY_SEPARATOR.'blocks');
+            if ($allowed === false) {
+                continue;
+            }
+            if (str_starts_with($real, $allowed.DIRECTORY_SEPARATOR)) {
+                return $real;
+            }
+        }
+
+        throw new NotFoundHttpException('Invalid block location.');
     }
 }

--- a/src/Controllers/PageBlockController.php
+++ b/src/Controllers/PageBlockController.php
@@ -22,26 +22,17 @@ class PageBlockController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    protected $template;
-    protected $page;
-    protected $pageblock;
-    protected $pageBlockRepository;
-    protected $resource;
-    protected $repeater;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Template $template, Page $page, PageBlock $pageblock, PageBlockRepository $pageBlockRepository, Resource $resource, Repeater $repeater)
-    {
-        $this->template = $template;
-        $this->page = $page;
-        $this->pageblock = $pageblock;
-        $this->pageBlockRepository = $pageBlockRepository;
-        $this->resource = $resource;
-        $this->repeater = $repeater;
+    public function __construct(
+        protected Template $template,
+        protected Page $page,
+        protected PageBlock $pageblock,
+        protected PageBlockRepository $pageBlockRepository,
+        protected Resource $resource,
+        protected Repeater $repeater,
+    ) {
     }
 
     /**

--- a/src/Controllers/PageController.php
+++ b/src/Controllers/PageController.php
@@ -13,6 +13,8 @@ use Chuckbe\Chuckcms\Models\Resource;
 use Chuckbe\Chuckcms\Models\Site;
 use Chuckbe\Chuckcms\Models\Template;
 use Chuckbe\Chuckcms\Models\User;
+use Chuckbe\Chuckcms\Requests\Pages\DeletePageRequest;
+use Chuckbe\Chuckcms\Requests\Pages\SavePageRequest;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
@@ -90,11 +92,8 @@ class PageController extends BaseController
      *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function save(Request $request)
+    public function save(SavePageRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'page_title' => 'max:185',
-        ]);
         if ($request['create']) {
             $this->pageRepository->create($request);
         }
@@ -110,12 +109,8 @@ class PageController extends BaseController
      *
      * @return string $status
      */
-    public function delete(Request $request)
+    public function delete(DeletePageRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'page_id' => 'required',
-        ]);
-
         $status = $this->page->deleteById($request->get('page_id'));
 
         return $status;

--- a/src/Controllers/PageController.php
+++ b/src/Controllers/PageController.php
@@ -4,6 +4,7 @@ namespace Chuckbe\Chuckcms\Controllers;
 
 use Chuckbe\Chuckcms\Chuck\PageBlockRepository;
 use Chuckbe\Chuckcms\Chuck\PageRepository;
+use Chuckbe\Chuckcms\Chuck\Support\TemplateBlocks;
 use Chuckbe\Chuckcms\Models\Page;
 use Chuckbe\Chuckcms\Models\PageBlock;
 use Chuckbe\Chuckcms\Models\Redirect;
@@ -215,45 +216,9 @@ class PageController extends BaseController
         $template = $this->template->where('id', $page->template_id)->first();
         $pageblocks = $this->pageBlockRepository->getRenderedByPageBlocks($this->pageblock->getAllByPageId($page->id));
 
-        $block_dir = array_slice(scandir('chuckbe/'.$template->slug.'/blocks'), 2);
-        $blocks = $this->dirToArray($template->path.'/blocks');
+        $blocks = TemplateBlocks::scan($template->path.'/blocks');
 
         return view('chuckcms::backend.pages.pagebuilder.index', compact('template', 'page', 'pageblocks', 'blocks'));
-    }
-
-    public function dirToArray($dir)
-    {
-        $result = [];
-
-        $cdir = scandir($dir);
-        foreach ($cdir as $key => $value) {
-            if (!in_array($value, ['.', '..'])) {
-                if (is_dir($dir.DIRECTORY_SEPARATOR.$value)) {
-                    $result[$value] = $this->dirToArray($dir.DIRECTORY_SEPARATOR.$value);
-                } else {
-                    if ($value !== '.DS_Store' && (strpos($value, '.html') !== false)) {
-                        $blockKey = str_replace('.html', '', $value);
-                        $blockName = str_replace('-', ' ', $blockKey);
-                        if (file_exists($dir.DIRECTORY_SEPARATOR.$blockKey.'.jpg')) {
-                            $blockImage = $dir.DIRECTORY_SEPARATOR.$blockKey.'.jpg';
-                        } elseif (file_exists($dir.DIRECTORY_SEPARATOR.$blockKey.'.jpeg')) {
-                            $blockImage = $dir.DIRECTORY_SEPARATOR.$blockKey.'.jpeg';
-                        } elseif (file_exists($dir.DIRECTORY_SEPARATOR.$blockKey.'.png')) {
-                            $blockImage = $dir.DIRECTORY_SEPARATOR.$blockKey.'.png';
-                        } else {
-                            $blockImage = 'https://ui-avatars.com/api/?length=5&size=150&name=BLOCK&background=0D8ABC&color=fff&font-size=0.2';
-                        }
-                        $result[$blockKey] = [
-                            'name'     => $blockName,
-                            'location' => $dir.DIRECTORY_SEPARATOR.$value,
-                            'img'      => $blockImage,
-                        ];
-                    }
-                }
-            }
-        }
-
-        return $result;
     }
 
     /**

--- a/src/Controllers/PageController.php
+++ b/src/Controllers/PageController.php
@@ -27,44 +27,21 @@ class PageController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $page;
-    private $pageRepository;
-    private $pageblock;
-    private $pageBlockRepository;
-    private $redirect;
-    private $resource;
-    private $repeater;
-    private $site;
-    private $template;
-    private $user;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
     public function __construct(
-        Page $page,
-        PageRepository $pageRepository,
-        PageBlock $pageblock,
-        PageBlockRepository $pageBlockRepository,
-        Redirect $redirect,
-        Resource $resource,
-        Repeater $repeater,
-        Site $site,
-        Template $template,
-        User $user
+        private Page $page,
+        private PageRepository $pageRepository,
+        private PageBlock $pageblock,
+        private PageBlockRepository $pageBlockRepository,
+        private Redirect $redirect,
+        private Resource $resource,
+        private Repeater $repeater,
+        private Site $site,
+        private Template $template,
+        private User $user,
     ) {
-        $this->page = $page;
-        $this->pageRepository = $pageRepository;
-        $this->pageblock = $pageblock;
-        $this->pageBlockRepository = $pageBlockRepository;
-        $this->redirect = $redirect;
-        $this->resource = $resource;
-        $this->repeater = $repeater;
-        $this->site = $site;
-        $this->template = $template;
-        $this->user = $user;
         $this->middleware('auth');
     }
 

--- a/src/Controllers/RedirectController.php
+++ b/src/Controllers/RedirectController.php
@@ -17,12 +17,9 @@ class RedirectController extends BaseController
 
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Redirect $redirect)
+    public function __construct(private Redirect $redirect)
     {
-        $this->redirect = $redirect;
     }
 
     /**

--- a/src/Controllers/RedirectController.php
+++ b/src/Controllers/RedirectController.php
@@ -3,6 +3,8 @@
 namespace Chuckbe\Chuckcms\Controllers;
 
 use Chuckbe\Chuckcms\Models\Redirect;
+use Chuckbe\Chuckcms\Requests\Redirects\CreateRedirectRequest;
+use Chuckbe\Chuckcms\Requests\Redirects\UpdateRedirectRequest;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
@@ -34,15 +36,9 @@ class RedirectController extends BaseController
         return view('chuckcms::backend.redirects.index', compact('redirects'));
     }
 
-    public function create(Request $request)
+    public function create(CreateRedirectRequest $request)
     {
         //$request['slug'] = str_slug($request->slug, '-');
-
-        $this->validate($request, [//@todo create custom Request class for redirect validation
-            'slug' => 'max:185|required|unique:redirects',
-            'to'   => 'required|max:185',
-            'type' => 'required|numeric|in:301,302',
-        ]);
 
         $redirect = Redirect::firstOrNew(
             ['slug' => $request['slug']],
@@ -55,16 +51,9 @@ class RedirectController extends BaseController
         }
     }
 
-    public function update(Request $request)
+    public function update(UpdateRedirectRequest $request)
     {
         //$request['slug'] = str_slug($request->slug, '-');
-
-        $this->validate($request, [//@todo create custom Request class for redirect validation
-            'id'   => 'required',
-            'slug' => 'required|max:185',
-            'to'   => 'required|max:185',
-            'type' => 'required|numeric|in:301,302',
-        ]);
 
         $redirect = Redirect::where('id', $request['id'])->update([
             'slug' => $request['slug'],

--- a/src/Controllers/SiteController.php
+++ b/src/Controllers/SiteController.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Validation\Rules\Password;
 
 class SiteController extends BaseController
 {
@@ -72,7 +73,7 @@ class SiteController extends BaseController
     public function activate(Request $request)
     {
         $this->validate(request(), [//@todo create custom Request class for user password validation
-            'password'       => 'required|min:8|regex:/^.*(?=.{3,})(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[\d\X])(?=.*[!$#%]).*$/',
+            'password'       => ['required', Password::min(8)->mixedCase()->letters()->numbers()->symbols()],
             'password_again' => 'required|same:password',
             '_user_token'    => 'required',
             '_user_id'       => 'required',

--- a/src/Controllers/SiteController.php
+++ b/src/Controllers/SiteController.php
@@ -18,20 +18,14 @@ class SiteController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $site;
-    private $siteRepository;
-    private $user;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(Site $site, SiteRepository $siteRepository, User $user)
-    {
-        $this->site = $site;
-        $this->siteRepository = $siteRepository;
-        $this->user = $user;
+    public function __construct(
+        private Site $site,
+        private SiteRepository $siteRepository,
+        private User $user,
+    ) {
     }
 
     public function save(Request $request)

--- a/src/Controllers/SiteController.php
+++ b/src/Controllers/SiteController.php
@@ -5,12 +5,12 @@ namespace Chuckbe\Chuckcms\Controllers;
 use Chuckbe\Chuckcms\Chuck\SiteRepository;
 use Chuckbe\Chuckcms\Models\Site;
 use Chuckbe\Chuckcms\Models\User;
+use Chuckbe\Chuckcms\Requests\Sites\SaveSiteRequest;
+use Chuckbe\Chuckcms\Requests\Users\ActivateUserRequest;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Validation\Rules\Password;
 
 class SiteController extends BaseController
 {
@@ -28,22 +28,8 @@ class SiteController extends BaseController
     ) {
     }
 
-    public function save(Request $request)
+    public function save(SaveSiteRequest $request)
     {
-        //validate the request
-        $this->validate(request(), [//@todo create custom Request class for site validation
-            'site_name'      => 'max:185|required',
-            'site_slug'      => 'max:70',
-            'site_domain'    => 'required',
-            'company.*'      => 'string|nullable',
-            'socialmedia.*'  => 'string|nullable',
-            'favicon.*'      => 'string|nullable',
-            'logo.*'         => 'string|nullable',
-            'integrations.*' => 'string|nullable',
-            'lang'           => 'array',
-            'site_id'        => 'required|nullable',
-        ]);
-
         //update or create settings
         $this->siteRepository->updateOrCreateFromRequest($request);
 
@@ -64,15 +50,8 @@ class SiteController extends BaseController
         return view('chuckcms::backend.users._accept', compact('user', 'token'));
     }
 
-    public function activate(Request $request)
+    public function activate(ActivateUserRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for user password validation
-            'password'       => ['required', Password::min(8)->mixedCase()->letters()->numbers()->symbols()],
-            'password_again' => 'required|same:password',
-            '_user_token'    => 'required',
-            '_user_id'       => 'required',
-        ]);
-
         $token = $request->get('_user_token');
         $user_id = $request->get('_user_id');
 

--- a/src/Controllers/TemplateController.php
+++ b/src/Controllers/TemplateController.php
@@ -16,18 +16,13 @@ class TemplateController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    protected $page;
-    protected $template;
-
     /**
      * Create a TemplateController instance.
-     *
-     * @return void
      */
-    public function __construct(Page $page, Template $template)
-    {
-        $this->page = $page;
-        $this->template = $template;
+    public function __construct(
+        protected Page $page,
+        protected Template $template,
+    ) {
     }
 
     /**

--- a/src/Controllers/TemplateController.php
+++ b/src/Controllers/TemplateController.php
@@ -4,10 +4,10 @@ namespace Chuckbe\Chuckcms\Controllers;
 
 use Chuckbe\Chuckcms\Models\Page;
 use Chuckbe\Chuckcms\Models\Template;
+use Chuckbe\Chuckcms\Requests\Templates\SaveTemplateRequest;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 
 class TemplateController extends BaseController
@@ -60,12 +60,8 @@ class TemplateController extends BaseController
      *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function save(Request $request)
+    public function save(SaveTemplateRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'template_id' => 'required',
-        ]);
-
         $this->template->updateFromRequest($request);
 
         return redirect()->route('dashboard.templates');

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Validation\Rules\Password;
 use Mail;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -101,7 +102,7 @@ class UserController extends BaseController
     public function activate(Request $request)
     {
         $this->validate(request(), [//@todo create custom Request class for user password validation
-            'password'       => 'required|min:8|regex:/^.*(?=.{3,})(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[\d\])(?=.*[!$#%]).*$/',
+            'password'       => ['required', Password::min(8)->mixedCase()->letters()->numbers()->symbols()],
             'password_again' => 'required|same:password',
             '_user_token'    => 'required',
             '_user_id'       => 'required',

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -5,13 +5,15 @@ namespace Chuckbe\Chuckcms\Controllers;
 use Chuckbe\Chuckcms\Chuck\UserRepository;
 use Chuckbe\Chuckcms\Mail\UserActivationMail;
 use Chuckbe\Chuckcms\Models\User;
+use Chuckbe\Chuckcms\Requests\Users\ActivateUserRequest;
+use Chuckbe\Chuckcms\Requests\Users\InviteUserRequest;
+use Chuckbe\Chuckcms\Requests\Users\SaveUserRequest;
 use ChuckSite;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Validation\Rules\Password;
 use Mail;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -44,14 +46,8 @@ class UserController extends BaseController
         return view('chuckcms::backend.users.index', compact('users', 'roles'));
     }
 
-    public function invite(Request $request)
+    public function invite(InviteUserRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'name'  => 'max:185|required',
-            'email' => 'email|required|unique:users',
-            'role'  => 'required|in:user,moderator,administrator,super-admin',
-        ]);
-
         // create the user
         $user = $this->user->create([
             'name'     => $request->get('name'),
@@ -94,15 +90,8 @@ class UserController extends BaseController
         return view('chuckcms::backend.users._accept', compact('user', 'token'));
     }
 
-    public function activate(Request $request)
+    public function activate(ActivateUserRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for user password validation
-            'password'       => ['required', Password::min(8)->mixedCase()->letters()->numbers()->symbols()],
-            'password_again' => 'required|same:password',
-            '_user_token'    => 'required',
-            '_user_id'       => 'required',
-        ]);
-
         $token = $request->get('_user_token');
         $user_id = $request->get('_user_id');
 
@@ -166,14 +155,8 @@ class UserController extends BaseController
         return 'success';
     }
 
-    public function save(Request $request)
+    public function save(SaveUserRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'name'  => 'max:185|required',
-            'email' => 'email|required',
-            'role'  => 'required|in:user,moderator,administrator,super-admin',
-        ]);
-
         // update the user
         $user = $this->user->create([// TODO CHANGE TO UPDATE METHOD
             'name'     => $request->get('name'),

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -22,18 +22,13 @@ class UserController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $user;
-    private $userRepository;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(User $user, UserRepository $userRepository)
-    {
-        $this->user = $user;
-        $this->userRepository = $userRepository;
+    public function __construct(
+        private User $user,
+        private UserRepository $userRepository,
+    ) {
     }
 
     /**

--- a/src/Controllers/UserRoleController.php
+++ b/src/Controllers/UserRoleController.php
@@ -18,18 +18,13 @@ class UserRoleController extends BaseController
     use DispatchesJobs;
     use ValidatesRequests;
 
-    private $user;
-    private $userRepository;
-
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
-    public function __construct(User $user, UserRepository $userRepository)
-    {
-        $this->user = $user;
-        $this->userRepository = $userRepository;
+    public function __construct(
+        private User $user,
+        private UserRepository $userRepository,
+    ) {
     }
 
     /**

--- a/src/Controllers/UserRoleController.php
+++ b/src/Controllers/UserRoleController.php
@@ -4,6 +4,8 @@ namespace Chuckbe\Chuckcms\Controllers;
 
 use Chuckbe\Chuckcms\Chuck\UserRepository;
 use Chuckbe\Chuckcms\Models\User;
+use Chuckbe\Chuckcms\Requests\UserRoles\CreateRoleRequest;
+use Chuckbe\Chuckcms\Requests\UserRoles\SaveRoleRequest;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
@@ -39,13 +41,8 @@ class UserRoleController extends BaseController
         return view('chuckcms::backend.users.roles.index', compact('roles'));
     }
 
-    public function create(Request $request)
+    public function create(CreateRoleRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'role_name'     => 'max:185|required',
-            'role_redirect' => 'max:255|required',
-        ]);
-
         $role = Role::firstOrCreate(['name' => $request->role_name], ['redirect' => $request->role_redirect]);
 
         return redirect()->route('dashboard.users.roles.edit', ['role' => $role->id])->with('notification', 'Rol aangemaakt!');
@@ -63,16 +60,8 @@ class UserRoleController extends BaseController
         return view('chuckcms::backend.users.roles.edit', compact('role', 'permissions'));
     }
 
-    public function save(Request $request)
+    public function save(SaveRoleRequest $request)
     {
-        $this->validate(request(), [//@todo create custom Request class for page validation
-            'role_name'            => 'max:185|required',
-            'role_redirect'        => 'max:255|required',
-            'role_id'              => 'required',
-            'permissions_name.*'   => 'required',
-            'permissions_active.*' => 'required',
-        ]);
-
         $role = Role::findById($request->role_id);
         $role->name = $request->role_name;
         $role->redirect = $request->role_redirect;

--- a/src/Models/Content.php
+++ b/src/Models/Content.php
@@ -2,12 +2,12 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property array $content
  */
-class Content extends Eloquent
+class Content extends Model
 {
     /**
      * The attributes that are mass assignable.

--- a/src/Models/Content.php
+++ b/src/Models/Content.php
@@ -2,6 +2,7 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
+use Chuckbe\Chuckcms\Chuck\Support\TagParser;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -91,31 +92,12 @@ class Content extends Model
 
     public function getUrlFromInput($url, $input)
     {
-        $fields = $this->getContents($url, '[', ']');
+        $fields = TagParser::between($url, '[', ']');
         $finalUrl = $url;
         foreach ($fields as $field) {
             $finalUrl = str_replace('['.$field.']', $input->get($field), $finalUrl);
         }
 
         return $finalUrl;
-    }
-
-    public function getContents($str, $startDelimiter, $endDelimiter)
-    {
-        $contents = [];
-        $startDelimiterLength = strlen($startDelimiter);
-        $endDelimiterLength = strlen($endDelimiter);
-        $startFrom = 0;
-        while (false !== ($contentStart = strpos($str, $startDelimiter, $startFrom))) {
-            $contentStart += $startDelimiterLength;
-            $contentEnd = strpos($str, $endDelimiter, $contentStart);
-            if (false === $contentEnd) {
-                break;
-            }
-            $contents[] = substr($str, $contentStart, $contentEnd - $contentStart);
-            $startFrom = $contentEnd + $endDelimiterLength;
-        }
-
-        return $contents;
     }
 }

--- a/src/Models/Form.php
+++ b/src/Models/Form.php
@@ -2,13 +2,13 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 /**
  * @property array $form
  */
-class Form extends Eloquent
+class Form extends Model
 {
     /**
      * The attributes that are mass assignable.

--- a/src/Models/Form.php
+++ b/src/Models/Form.php
@@ -3,6 +3,7 @@
 namespace Chuckbe\Chuckcms\Models;
 
 use Eloquent;
+use Illuminate\Support\Str;
 
 /**
  * @property array $form
@@ -55,7 +56,7 @@ class Form extends Eloquent
                     if ($fieldValue['type'] == 'file') {
                         if ($input->hasFile($fieldKey)) {
                             $avatar = $input->file($fieldKey);
-                            $random = str_random(8);
+                            $random = Str::random(8);
                             $filename = time().'_'.$random.'.'.$avatar->getClientOriginalExtension();
                             if (!file_exists(public_path('/files/uploads/'))) {
                                 mkdir(public_path('/files/uploads/'), 0755, true);

--- a/src/Models/Form.php
+++ b/src/Models/Form.php
@@ -2,6 +2,7 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
+use Chuckbe\Chuckcms\Chuck\Support\TagParser;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -115,7 +116,7 @@ class Form extends Model
     {
         $mailData = [];
         foreach ($sendData as $sendKey => $sendValue) {
-            $findThis = $this->getResources($sendValue, '[', ']');
+            $findThis = TagParser::between($sendValue, '[', ']');
             if (count($findThis) > 0) {
                 foreach ($findThis as $founded) {
                     if (strpos($founded, $input->get('_form_slug')) !== false) {
@@ -139,26 +140,5 @@ class Form extends Model
         }
 
         return $mailData;
-    }
-
-    public function getResources($str, $startDelimiter, $endDelimiter)
-    {
-        $contents = [];
-        $startDelimiterLength = strlen($startDelimiter);
-        $endDelimiterLength = strlen($endDelimiter);
-        $startFrom = 0;
-        $contentStart = 0;
-        $contentEnd = 0;
-        while (false !== ($contentStart = strpos($str, $startDelimiter, $startFrom))) {
-            $contentStart += $startDelimiterLength;
-            $contentEnd = strpos($str, $endDelimiter, $contentStart);
-            if (false === $contentEnd) {
-                break;
-            }
-            $contents[] = substr($str, $contentStart, $contentEnd - $contentStart);
-            $startFrom = $contentEnd + $endDelimiterLength;
-        }
-
-        return $contents;
     }
 }

--- a/src/Models/FormEntry.php
+++ b/src/Models/FormEntry.php
@@ -2,13 +2,13 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property string $slug
  * @property array  $entry
  */
-class FormEntry extends Eloquent
+class FormEntry extends Model
 {
     /**
      * The attributes that are mass assignable.

--- a/src/Models/MenuItems.php
+++ b/src/Models/MenuItems.php
@@ -2,7 +2,7 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property int    $id
@@ -14,7 +14,7 @@ use Eloquent;
  * @property int    $parent
  * @property int    $depth
  */
-class MenuItems extends Eloquent
+class MenuItems extends Model
 {
     protected $table = null;
 

--- a/src/Models/Menus.php
+++ b/src/Models/Menus.php
@@ -2,13 +2,13 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property int    $id
  * @property string $name
  */
-class Menus extends Eloquent
+class Menus extends Model
 {
     protected $table = 'menus';
 

--- a/src/Models/Module.php
+++ b/src/Models/Module.php
@@ -2,9 +2,9 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
-class Module extends Eloquent
+class Module extends Model
 {
     /**
      * The attributes that are mass assignable.

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -3,12 +3,12 @@
 namespace Chuckbe\Chuckcms\Models;
 
 use ChuckSite;
-use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Model;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 use Spatie\Translatable\HasTranslations;
 
-class Page extends Eloquent implements Sortable
+class Page extends Model implements Sortable
 {
     use SortableTrait;
     use HasTranslations;

--- a/src/Models/PageBlock.php
+++ b/src/Models/PageBlock.php
@@ -3,9 +3,9 @@
 namespace Chuckbe\Chuckcms\Models;
 
 use Chuckbe\Chuckcms\Chuck\PageBlockRepository;
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
-class PageBlock extends Eloquent
+class PageBlock extends Model
 {
     public function page()
     {

--- a/src/Models/Redirect.php
+++ b/src/Models/Redirect.php
@@ -2,14 +2,14 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property string $slug
  * @property string $to
  * @property int    $type
  */
-class Redirect extends Eloquent
+class Redirect extends Model
 {
     /**
      * The attributes that are mass assignable.

--- a/src/Models/Repeater.php
+++ b/src/Models/Repeater.php
@@ -2,7 +2,7 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $page
  * @property array  $json
  */
-class Repeater extends Eloquent
+class Repeater extends Model
 {
     use SoftDeletes;
 

--- a/src/Models/Resource.php
+++ b/src/Models/Resource.php
@@ -2,13 +2,13 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property string $slug
  * @property array  $json
  */
-class Resource extends Eloquent
+class Resource extends Model
 {
     protected $casts = [
         'json' => 'array',

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -2,12 +2,12 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property array $settings
  */
-class Site extends Eloquent
+class Site extends Model
 {
     /**
      * The attributes that are mass assignable.

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -2,10 +2,10 @@
 
 namespace Chuckbe\Chuckcms\Models;
 
-use Eloquent;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
-class Template extends Eloquent
+class Template extends Model
 {
     public function pages()
     {

--- a/src/Providers/ChuckTemplateServiceProvider.php
+++ b/src/Providers/ChuckTemplateServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Chuckbe\Chuckcms\Providers;
 
 use Chuckbe\Chuckcms\Models\Template as TemplateModel;
+use Exception;
 use Illuminate\Support\ServiceProvider;
 
 class ChuckTemplateServiceProvider extends ServiceProvider

--- a/src/Requests/Content/DeleteRepeaterRequest.php
+++ b/src/Requests/Content/DeleteRepeaterRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Content;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteRepeaterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'content_id' => 'required',
+        ];
+    }
+}

--- a/src/Requests/Content/DeleteResourceRequest.php
+++ b/src/Requests/Content/DeleteResourceRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Content;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteResourceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'resource_id' => 'required',
+        ];
+    }
+}

--- a/src/Requests/Content/ImportRepeaterRequest.php
+++ b/src/Requests/Content/ImportRepeaterRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Content;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportRepeaterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'slug' => 'required',
+            'file' => 'required|file|mimetypes:application/json,application/octet-stream,text/plain',
+        ];
+    }
+}

--- a/src/Requests/Content/SaveResourceRequest.php
+++ b/src/Requests/Content/SaveResourceRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Content;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SaveResourceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'slug'             => 'required',
+            'resource_key.*'   => 'required',
+            'resource_value.*' => 'required',
+        ];
+    }
+}

--- a/src/Requests/Pages/DeletePageRequest.php
+++ b/src/Requests/Pages/DeletePageRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Pages;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeletePageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'page_id' => 'required',
+        ];
+    }
+}

--- a/src/Requests/Pages/SavePageRequest.php
+++ b/src/Requests/Pages/SavePageRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Pages;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SavePageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'page_title' => 'max:185',
+        ];
+    }
+}

--- a/src/Requests/Redirects/CreateRedirectRequest.php
+++ b/src/Requests/Redirects/CreateRedirectRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Redirects;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateRedirectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'slug' => 'max:185|required|unique:redirects',
+            'to'   => 'required|max:185',
+            'type' => 'required|numeric|in:301,302',
+        ];
+    }
+}

--- a/src/Requests/Redirects/UpdateRedirectRequest.php
+++ b/src/Requests/Redirects/UpdateRedirectRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Redirects;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRedirectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id'   => 'required',
+            'slug' => 'required|max:185',
+            'to'   => 'required|max:185',
+            'type' => 'required|numeric|in:301,302',
+        ];
+    }
+}

--- a/src/Requests/Sites/SaveSiteRequest.php
+++ b/src/Requests/Sites/SaveSiteRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Sites;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SaveSiteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'site_name'      => 'max:185|required',
+            'site_slug'      => 'max:70',
+            'site_domain'    => 'required',
+            'company.*'      => 'string|nullable',
+            'socialmedia.*'  => 'string|nullable',
+            'favicon.*'      => 'string|nullable',
+            'logo.*'         => 'string|nullable',
+            'integrations.*' => 'string|nullable',
+            'lang'           => 'array',
+            'site_id'        => 'required|nullable',
+        ];
+    }
+}

--- a/src/Requests/Templates/SaveTemplateRequest.php
+++ b/src/Requests/Templates/SaveTemplateRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Templates;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SaveTemplateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'template_id' => 'required',
+        ];
+    }
+}

--- a/src/Requests/UserRoles/CreateRoleRequest.php
+++ b/src/Requests/UserRoles/CreateRoleRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\UserRoles;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'role_name'     => 'max:185|required',
+            'role_redirect' => 'max:255|required',
+        ];
+    }
+}

--- a/src/Requests/UserRoles/SaveRoleRequest.php
+++ b/src/Requests/UserRoles/SaveRoleRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\UserRoles;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SaveRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'role_name'            => 'max:185|required',
+            'role_redirect'        => 'max:255|required',
+            'role_id'              => 'required',
+            'permissions_name.*'   => 'required',
+            'permissions_active.*' => 'required',
+        ];
+    }
+}

--- a/src/Requests/Users/ActivateUserRequest.php
+++ b/src/Requests/Users/ActivateUserRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Users;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class ActivateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'password'       => ['required', Password::min(8)->mixedCase()->letters()->numbers()->symbols()],
+            'password_again' => 'required|same:password',
+            '_user_token'    => 'required',
+            '_user_id'       => 'required',
+        ];
+    }
+}

--- a/src/Requests/Users/InviteUserRequest.php
+++ b/src/Requests/Users/InviteUserRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Users;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class InviteUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name'  => 'max:185|required',
+            'email' => 'email|required|unique:users',
+            'role'  => 'required|in:user,moderator,administrator,super-admin',
+        ];
+    }
+}

--- a/src/Requests/Users/SaveUserRequest.php
+++ b/src/Requests/Users/SaveUserRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Chuckbe\Chuckcms\Requests\Users;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SaveUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name'  => 'max:185|required',
+            'email' => 'email|required',
+            'role'  => 'required|in:user,moderator,administrator,super-admin',
+        ];
+    }
+}


### PR DESCRIPTION
Phase 1 of the package cleanup. Mechanical refactors + the two crash-bug security fixes you green-lit. Each item is its own commit so review can be done one diff at a time.

Phase 2 (single-action class extraction) and Phase 3 (Laravel 11/12 + dependency bumps + Honeypot swap) will land as separate PRs.

## Commits in this PR

| # | Commit | Notes |
|---|---|---|
| 1 | `fix(security): prevent path traversal in PageBlockController::addBlock*` | `addBlockTop`/`addBlockBottom` read a file path straight from the request and stored its contents as a page-block body. Any user with `edit pagebuilder` could read arbitrary files. Now constrained to `.html` files under an active template's `blocks/` directory via `realpath`. |
| 2 | `fix(security): replace broken password regex with Password rule` | Both `UserController::activate` and `SiteController::activate` had a hand-rolled regex with an unescaped `]` (and a stray `\X` in SiteController). The character class never closed, so the rule either threw or never matched. Replaced with Laravel's `Password::min(8)->mixedCase()->letters()->numbers()->symbols()`. |
| 3 | `fix: replace removed str_random() helper with Str::random()` | `Form::storeEntry` called `str_random(8)` (removed in Laravel 5.9) when uploading files — silently broken for years. |
| 4 | `fix: import Exception in ChuckTemplateServiceProvider` | The "no template defined" error path threw a class-relative `Chuckbe\Chuckcms\Providers\Exception` because the global `Exception` was never imported. The very error that explained the misconfiguration would itself fatal. |
| 5 | `refactor: extend Eloquent\Model directly in all models` | All 13 models extended the global `Eloquent` facade alias. That works under L9/10 but a package shouldn't depend on consumer-side aliases. Now `extends Illuminate\Database\Eloquent\Model`. |
| 6 | `chore: drop dead code from service provider and routes accessor` | Removed the no-op `$this->app['App\User'] = ...`, the unused `getMigrationFileName()` helper + its `Filesystem`/`Collection` imports, and three empty `permission:*` middleware groups. |
| 7 | `refactor: extract dirToArray() into Chuck\Support\TemplateBlocks` | 35-line filesystem walker hanging off `PageController` moved into a small helper. Also dropped a dead `scandir('chuckbe/'.$template->slug.'/blocks')` call whose result was never used. |
| 8 | `refactor: extract duplicated tag parser into Chuck\Support\TagParser` | The same delimiter-scanning helper was copy-pasted three times: `getResources()` in `Models\Form` and `Chuck\PageBlockRepository`, and `getContents()` in `Models\Content`. All three were byte-equivalent. |
| 9 | `refactor: deduplicate PageBlockRepository render methods` | `getRenderedByPageBlocks` and `getRenderedByPageBlock` were 95% identical. Body-rendering pipeline extracted into a private `renderBody()`; the `'order'` vs `'lang'` difference in the returned arrays is preserved. |
| 10 | `refactor: use constructor property promotion in controllers` | All 13 controllers converted to PHP 8 promoted ctors. `FrontEndController` also dropped a vestigial `Role $role` ctor parameter that had no matching property and was never used. |
| 11 | `refactor: extract @todo validations into FormRequest classes` | 15 new FormRequests under `src/Requests/{Pages,Templates,Sites,Users,UserRoles,Content,Redirects}`, each a 1:1 lift of the original rules. `authorize()` returns `true` because route-level `permission:` middleware still gates access. |

## What this PR deliberately does NOT do

- **`Repeater::__get` is untouched** — needed by templates and other downstream packages.
- **Magic-string `return 'success'/'error'/'false'` returns are untouched** — frontend JS depends on those literal strings, so converting to `JsonResponse` would be a behavior change. Phase 2 candidate.
- **No Honeypot swap, no `spatie/permission` namespace move, no composer bumps** — those belong to Phase 3 alongside the actual L11/12 dependency upgrades. Each will land in its own commit then.
- **No fixes for the other open security findings** (`UserController::save` create-instead-of-update, mail open-relay surface from form builder, MenuController missing validation, `$page->css/js` self-XSS, `Template::getEmailTemplates` path concatenation). Those are functional/policy decisions and ride along with Phase 2 where new action classes can encapsulate authorization properly.

## Test plan

There are no existing tests to run. Manual verification suggested:

- [ ] Page builder: open a page, add a block from a template, verify the block appears (commit 1, 7).
- [ ] Page builder: try POSTing `{location: '/etc/passwd', page_id: ..., name: 'foo'}` to `/pageblock/add-block-top` — must 404 (commit 1).
- [ ] User invitation flow: invite a user, click the activation link, set a password — must require letter + number + symbol + min 8 chars (commit 2).
- [ ] Form with file upload field: submit with a file — must save successfully (commit 3).
- [ ] Page block rendering: page with `[%URL%]`, `[LOOP=...]`, `[FORM=...]`, and plain `[resource+key]` tags — all four still resolve (commit 9).
- [ ] Save a page, save a template, save the site settings, save a user role — validation messages should still surface from the new FormRequests (commit 11).

https://claude.ai/code/session_018Cj4NUuHVtXVzKJPxLHwkU